### PR TITLE
credential name is priority over username

### DIFF
--- a/node-reddit.html
+++ b/node-reddit.html
@@ -92,7 +92,7 @@
         access_token: {type:"password", required: false}
       },
       label: function() {
-        return this.username || this.name;
+        return this.name || this.username;
       },
       exportable: false,
       icon: "snoo2.png",


### PR DESCRIPTION
Hey team,

If we set up different apps with the same reddit username, we want to be able to distinguish between the credentials.  This patch allows the `name` field of a `reddit-credentials` node to have the display priority over the `username` field (if `name` is set).